### PR TITLE
Feature/interactive combat items

### DIFF
--- a/jules/plan012-report.md
+++ b/jules/plan012-report.md
@@ -41,6 +41,21 @@ This report details the successful implementation of interactive combat and item
 - Existing tests were cleaned up, and the renderer tests were fixed to align with the refactored rendering engine.
 - All tests are currently passing.
 
+## Post-Implementation Bug Fixes and Refinements
+
+Following the initial implementation, user feedback highlighted several issues and requested new features, which have now been addressed:
+
+- **Game Freeze During Combat:** A critical bug was found where the game would become unresponsive during combat. This was traced to two issues:
+    1.  An incorrect hardcoded entity key for the player was preventing the renderer from finding the player's sprite for animations.
+    2.  The game logic in `handleAttack` was using the wrong ID to look up monster data, causing the turn-based loop to fail.
+    - **Fix:** Both issues were resolved by correctly using dynamic entity keys and fixing the data lookup logic in `handleAttack`. The turn-based combat loop is now stable.
+
+- **Missing Monster Attack:** The game freeze bug was also the cause of the missing monster attack turn. With the freeze resolved, monsters now correctly attack back in a turn-based manner.
+
+- **Combat Round Limit:** A new feature was added to limit combat to a maximum of 8 rounds. If the battle is not decided by the end of the 8th round, combat ends, and the player is returned to their pre-battle state, free to move again.
+
+- **Negative Damage Display:** The damage animation was updated to display the damage value as a negative number (e.g., "-9"), as requested.
+
 ## Conclusion
 
-The implementation of `plan012` has successfully introduced a layer of dynamic, interactive animations to the game, significantly improving the user experience for combat and item collection. The underlying systems are now more robust and extensible for future development.
+The implementation of `plan012` has successfully introduced a layer of dynamic, interactive animations to the game, significantly improving the user experience for combat and item collection. Subsequent bug fixes and refinements have made the system robust and aligned with all user requirements. The underlying systems are now more stable and extensible for future development.

--- a/src/core/logic.ts
+++ b/src/core/logic.ts
@@ -1,6 +1,8 @@
 import { GameState, IPlayer, IMonster, ICharacter, EquipmentSlot, Action } from './types';
 import * as _ from 'lodash';
 
+const MAX_COMBAT_ROUNDS = 8;
+
 export function handleMove(state: GameState, dx: number, dy: number): GameState {
     const newState = _.cloneDeep(state);
     const newX = newState.player.x + dx;
@@ -17,7 +19,14 @@ export function handleMove(state: GameState, dx: number, dy: number): GameState 
         if (destinationEntity.type === 'item') {
             newState.interactionState = { type: 'item_pickup', itemId: destinationEntityKey };
         } else if (destinationEntity.type === 'monster') {
-            newState.interactionState = { type: 'battle', monsterId: destinationEntityKey, turn: 'player', playerHp: newState.player.hp, monsterHp: newState.monsters[destinationEntityKey].hp };
+            newState.interactionState = {
+                type: 'battle',
+                monsterId: destinationEntityKey,
+                turn: 'player',
+                playerHp: newState.player.hp,
+                monsterHp: newState.monsters[destinationEntityKey].hp,
+                round: 1,
+            };
         }
     } else {
         newState.player.x = newX;
@@ -70,22 +79,24 @@ export function handleStartBattle(state: GameState, monsterEntityKey: string): G
         turn,
         playerHp: newState.player.hp,
         monsterHp: monster.hp,
+        round: 1,
     };
 
     return newState;
 }
 
-export function handleAttack(state: GameState, attackerId: string, defenderId: string): GameState {
+export function handleAttack(state: GameState, attackerDataId: string, defenderDataId: string): GameState {
     const newState = _.cloneDeep(state);
     if (newState.interactionState.type !== 'battle') return state;
 
-    const attacker = attackerId === 'player' ? newState.player : newState.monsters[attackerId];
-    const defender = defenderId === 'player' ? newState.player : newState.monsters[defenderId];
+    const attacker = attackerDataId === 'player' ? newState.player : Object.values(newState.monsters).find(m => m.id === attackerDataId);
+    const defender = defenderDataId === 'player' ? newState.player : Object.values(newState.monsters).find(m => m.id === defenderDataId);
+
     if (!attacker || !defender) return state;
 
     const damage = calculateDamage(attacker, defender);
 
-    if (defenderId === 'player') {
+    if (defenderDataId === 'player') {
         newState.interactionState.playerHp -= damage;
     } else {
         newState.interactionState.monsterHp -= damage;
@@ -94,23 +105,31 @@ export function handleAttack(state: GameState, attackerId: string, defenderId: s
     if (newState.interactionState.playerHp <= 0 || newState.interactionState.monsterHp <= 0) {
         newState.interactionState.turn = 'battle_end';
     } else {
-        newState.interactionState.turn = newState.interactionState.turn === 'player' ? 'monster' : 'player';
+        if (newState.interactionState.turn === 'monster') {
+            newState.interactionState.round++;
+        }
+
+        if (newState.interactionState.round > MAX_COMBAT_ROUNDS) {
+            newState.interactionState.turn = 'battle_end';
+        } else {
+            newState.interactionState.turn = newState.interactionState.turn === 'player' ? 'monster' : 'player';
+        }
     }
 
     return newState;
 }
 
-export function handleEndBattle(state: GameState, winnerId: string): GameState {
+export function handleEndBattle(state: GameState, winnerId: string | null, reason: 'hp_depleted' | 'timeout'): GameState {
     const newState = _.cloneDeep(state);
     if (newState.interactionState.type !== 'battle') return state;
 
     const monsterEntityKey = newState.interactionState.monsterId;
 
-    if (winnerId === 'player') {
+    if (reason === 'hp_depleted' && winnerId === 'player') {
         newState.player.hp = newState.interactionState.playerHp;
         delete newState.entities[monsterEntityKey];
         delete newState.monsters[monsterEntityKey];
-    } else {
+    } else if (reason === 'hp_depleted' && winnerId !== 'player') {
         newState.player.hp = 0;
     }
 

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -103,7 +103,7 @@ export class GameStateManager {
                 newState = handleAttack(this.currentState, action.payload.attackerId, action.payload.defenderId);
                 break;
             case 'END_BATTLE':
-                newState = handleEndBattle(this.currentState, action.payload.winnerId);
+                newState = handleEndBattle(this.currentState, action.payload.winnerId, action.payload.reason);
                 break;
             default:
                 newState = this.currentState;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -101,7 +101,8 @@ export type InteractionState =
         turn: 'player' | 'monster' | 'battle_end';
         playerHp: number;
         monsterHp: number;
-      };
+        round: number;
+    };
 
 export interface GameState {
     currentFloor: number;
@@ -121,7 +122,7 @@ export type Action =
     | { type: 'OPEN_DOOR'; payload: { doorId: string } }
     | { type: 'START_BATTLE'; payload: { monsterId: string } }
     | { type: 'ATTACK'; payload: { attackerId: string, defenderId: string } }
-    | { type: 'END_BATTLE'; payload: { winnerId: string } };
+    | { type: 'END_BATTLE'; payload: { winnerId: string | null, reason: 'hp_depleted' | 'timeout' } };
 
 export interface SaveData {
     timestamp: number;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -79,14 +79,12 @@ export class Renderer {
     public syncSprites(state: GameState): void {
         const allEntityIds = Object.keys(state.entities);
 
-        // Sync existing and new sprites
         for (const entityId of allEntityIds) {
             const entity = state.entities[entityId];
             if (!entity) continue;
 
             let sprite = this.entitySprites.get(entityId);
             if (!sprite) {
-                // Create new sprite
                 let textureAlias = '';
                 if (entity.type === 'player_start') textureAlias = 'player';
                 else if (entity.type === 'monster') textureAlias = entity.id;
@@ -96,21 +94,19 @@ export class Renderer {
                     sprite = new Sprite(Assets.get(textureAlias));
                     sprite.width = TILE_SIZE;
                     sprite.height = TILE_SIZE;
-                    sprite.anchor.set(0.5); // Set anchor to center for animations
+                    sprite.anchor.set(0.5);
                     this.entitySprites.set(entityId, sprite);
                     this.entityContainer.addChild(sprite);
                 }
             }
 
             if (sprite) {
-                // Update sprite properties
                 sprite.x = entity.x * TILE_SIZE + TILE_SIZE / 2;
                 sprite.y = entity.y * TILE_SIZE + TILE_SIZE / 2;
                 sprite.visible = true;
             }
         }
 
-        // Hide or remove sprites for entities that no longer exist
         for (const [entityId, sprite] of this.entitySprites.entries()) {
             if (!state.entities[entityId]) {
                 sprite.visible = false;
@@ -119,7 +115,6 @@ export class Renderer {
     }
 
     public render(state: GameState): void {
-        // The main render call now syncs sprites and updates the HUD
         this.syncSprites(state);
         this.hud.update(state);
     }
@@ -133,10 +128,16 @@ export class Renderer {
         const playerSprite = this.entitySprites.get(playerKey);
         const itemSprite = this.entitySprites.get(state.interactionState.itemId);
 
-        if (!playerSprite || !itemSprite) return;
+        if (!playerSprite || !itemSprite) {
+            onComplete();
+            return;
+        }
 
         const item = state.entities[state.interactionState.itemId];
-        if(!item) return;
+        if(!item) {
+            onComplete();
+            return;
+        }
 
         const targetX = item.x * TILE_SIZE + TILE_SIZE / 2;
         const targetY = item.y * TILE_SIZE + TILE_SIZE / 2;
@@ -164,7 +165,10 @@ export class Renderer {
         const attackerSprite = this.entitySprites.get(attackerId);
         const defenderSprite = this.entitySprites.get(defenderId);
 
-        if (!attackerSprite || !defenderSprite) return;
+        if (!attackerSprite || !defenderSprite) {
+            onComplete();
+            return;
+        }
 
         const originalX = attackerSprite.x;
         const originalY = attackerSprite.y;
@@ -182,7 +186,7 @@ export class Renderer {
             repeat: 1,
         });
 
-        const damageText = new Text(String(damage), { fontSize: 24, fill: 'red', fontWeight: 'bold' });
+        const damageText = new Text(`-${damage}`, { fontSize: 24, fill: 'red', fontWeight: 'bold' });
         damageText.x = defenderSprite.x;
         damageText.y = defenderSprite.y - TILE_SIZE / 2;
         damageText.anchor.set(0.5);

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -114,9 +114,6 @@ export class Renderer {
         for (const [entityId, sprite] of this.entitySprites.entries()) {
             if (!state.entities[entityId]) {
                 sprite.visible = false;
-                // Optionally, you can remove the sprite completely if entities are permanently removed
-                // this.entityContainer.removeChild(sprite);
-                // this.entitySprites.delete(entityId);
             }
         }
     }
@@ -130,7 +127,10 @@ export class Renderer {
     public async animateItemPickup(state: GameState, onComplete: () => void): Promise<void> {
         if (state.interactionState.type !== 'item_pickup') return;
 
-        const playerSprite = this.entitySprites.get('player_start_0_0'); // Assumes player id is stable
+        const playerKey = Object.keys(state.entities).find(k => state.entities[k].type === 'player_start');
+        if (!playerKey) return;
+
+        const playerSprite = this.entitySprites.get(playerKey);
         const itemSprite = this.entitySprites.get(state.interactionState.itemId);
 
         if (!playerSprite || !itemSprite) return;
@@ -143,7 +143,6 @@ export class Renderer {
 
         const tl = gsap.timeline({ onComplete });
 
-        // Player jumps to item position
         tl.to(playerSprite, {
             x: targetX,
             y: targetY,
@@ -151,7 +150,6 @@ export class Renderer {
             ease: 'power1.inOut',
         });
 
-        // Item animates up, fades out, and shrinks
         tl.to(itemSprite, {
             y: targetY - TILE_SIZE,
             alpha: 0,
@@ -159,7 +157,7 @@ export class Renderer {
             height: itemSprite.height * 0.5,
             duration: 0.5,
             ease: 'power1.in',
-        }, '-=0.2'); // Start this animation slightly before player lands
+        }, '-=0.2');
     }
 
     public async animateAttack(attackerId: string, defenderId: string, damage: number, onComplete: () => void): Promise<void> {
@@ -175,7 +173,6 @@ export class Renderer {
 
         const tl = gsap.timeline({ onComplete });
 
-        // Attacker hops towards defender
         tl.to(attackerSprite, {
             x: (originalX + targetX) / 2,
             y: (originalY + targetY) / 2,
@@ -185,7 +182,6 @@ export class Renderer {
             repeat: 1,
         });
 
-        // Damage text appears and floats up
         const damageText = new Text(String(damage), { fontSize: 24, fill: 'red', fontWeight: 'bold' });
         damageText.x = defenderSprite.x;
         damageText.y = defenderSprite.y - TILE_SIZE / 2;

--- a/src/scenes/game-scene.ts
+++ b/src/scenes/game-scene.ts
@@ -98,8 +98,12 @@ export class GameScene extends BaseScene {
 
         const battleState = state.interactionState;
         if (battleState.turn === 'battle_end') {
-            const winnerId = battleState.playerHp > 0 ? 'player' : battleState.monsterId;
-            this.gameStateManager.dispatch({ type: 'END_BATTLE', payload: { winnerId } });
+            if (battleState.round > 8) {
+                this.gameStateManager.dispatch({ type: 'END_BATTLE', payload: { winnerId: null, reason: 'timeout' } });
+            } else {
+                const winnerId = battleState.playerHp > 0 ? 'player' : battleState.monsterId;
+                this.gameStateManager.dispatch({ type: 'END_BATTLE', payload: { winnerId, reason: 'hp_depleted' } });
+            }
             this.renderer.render(this.gameStateManager.getState());
             return;
         }

--- a/src/scenes/game-scene.ts
+++ b/src/scenes/game-scene.ts
@@ -18,6 +18,7 @@ export class GameScene extends BaseScene {
     private renderer: Renderer;
     private inputManager: InputManager;
     private isAnimating: boolean = false;
+    private playerEntityKey: string | undefined;
 
     constructor(sceneManager: SceneManager) {
         super(sceneManager);
@@ -48,6 +49,7 @@ export class GameScene extends BaseScene {
 
         this.gameStateManager = new GameStateManager();
         this.gameStateManager.initializeState(initialState);
+        this.playerEntityKey = Object.keys(initialState.entities).find(k => initialState.entities[k].type === 'player_start');
         this.renderer.initialize(this.gameStateManager.getState());
 
         this.inputManager.on('action', (action) => this.handleAction(action));
@@ -64,6 +66,10 @@ export class GameScene extends BaseScene {
     }
 
     private processInteraction(state: GameState): void {
+        if (this.isAnimating) {
+            return;
+        }
+
         switch (state.interactionState.type) {
             case 'item_pickup':
                 this.handleItemPickup(state);
@@ -88,7 +94,7 @@ export class GameScene extends BaseScene {
     }
 
     private handleBattle(state: GameState): void {
-        if (!this.gameStateManager) return;
+        if (!this.gameStateManager || !this.playerEntityKey) return;
 
         const battleState = state.interactionState;
         if (battleState.turn === 'battle_end') {
@@ -109,8 +115,8 @@ export class GameScene extends BaseScene {
 
         const attacker = battleState.turn === 'player' ? player : monster;
         const defender = battleState.turn === 'player' ? monster : player;
-        const attackerId = battleState.turn === 'player' ? 'player_start_0_0' : battleState.monsterId;
-        const defenderId = battleState.turn === 'player' ? battleState.monsterId : 'player_start_0_0';
+        const attackerId = battleState.turn === 'player' ? this.playerEntityKey : battleState.monsterId;
+        const defenderId = battleState.turn === 'player' ? battleState.monsterId : this.playerEntityKey;
 
         const damage = calculateDamage(attacker, defender);
 


### PR DESCRIPTION
This pull request focuses on post-implementation bug fixes and gameplay refinements for the interactive combat system, addressing user feedback and improving system robustness. The most significant changes include fixing a critical combat freeze bug, implementing a combat round limit, refining battle logic, and improving animation and rendering reliability.

**Combat Logic Improvements:**

* Fixed critical bug where the game would freeze during combat by correctly using dynamic entity keys for the player and fixing monster data lookups in `handleAttack`. This also ensures monsters attack back as intended in turn-based combat. [[1]](diffhunk://#diff-c525ba27dff0525dec5fc8672bc34bc91013afeccbe61ef1282ffcc519a417f1R82-R132) [[2]](diffhunk://#diff-8926708dd634f0dea01836a3ba59c0283ea3cac7b52f3fe7b68dd967d50822eeL82-L89) [[3]](diffhunk://#diff-8926708dd634f0dea01836a3ba59c0283ea3cac7b52f3fe7b68dd967d50822eeL99-R171) [[4]](diffhunk://#diff-bd8d23c132de1417c3f41cd2756dd7c79452266cd63fba97ca17c5893bce10dfR21) [[5]](diffhunk://#diff-bd8d23c132de1417c3f41cd2756dd7c79452266cd63fba97ca17c5893bce10dfR52)
* Introduced a combat round limit: battles now end after 8 rounds if undecided, returning the player to their pre-battle state. The relevant logic was added to the combat state and battle handling functions. [[1]](diffhunk://#diff-c525ba27dff0525dec5fc8672bc34bc91013afeccbe61ef1282ffcc519a417f1R4-R5) [[2]](diffhunk://#diff-c525ba27dff0525dec5fc8672bc34bc91013afeccbe61ef1282ffcc519a417f1L20-R29) [[3]](diffhunk://#diff-80ebcd3dc48e85c12b2c8484c5355662ab98ceea358660eb3af536c584f6fa44R104) [[4]](diffhunk://#diff-bd8d23c132de1417c3f41cd2756dd7c79452266cd63fba97ca17c5893bce10dfL91-R106)

**Battle State and Action Refinements:**

* Updated the `InteractionState` and `Action` types to track the current round and to specify the reason for battle ending (`hp_depleted` or `timeout`). [[1]](diffhunk://#diff-80ebcd3dc48e85c12b2c8484c5355662ab98ceea358660eb3af536c584f6fa44R104) [[2]](diffhunk://#diff-80ebcd3dc48e85c12b2c8484c5355662ab98ceea358660eb3af536c584f6fa44L124-R125)
* Updated `handleEndBattle` and related dispatch logic to accommodate the new round limit and reasons for ending a battle. [[1]](diffhunk://#diff-c525ba27dff0525dec5fc8672bc34bc91013afeccbe61ef1282ffcc519a417f1R82-R132) [[2]](diffhunk://#diff-7c4137edcbb583fb14dc467e3f61f28a2af494161cab16bc9f0010c3dc2ab0b6L106-R106) [[3]](diffhunk://#diff-bd8d23c132de1417c3f41cd2756dd7c79452266cd63fba97ca17c5893bce10dfL91-R106)

**Renderer and Animation Reliability:**

* Renderer now dynamically finds the player entity key instead of relying on a hardcoded value, preventing animation failures if the entity key changes. Also, improved robustness of item pickup and attack animations by ensuring callbacks are always called, even if sprites are missing. [[1]](diffhunk://#diff-8926708dd634f0dea01836a3ba59c0283ea3cac7b52f3fe7b68dd967d50822eeL99-R171) [[2]](diffhunk://#diff-bd8d23c132de1417c3f41cd2756dd7c79452266cd63fba97ca17c5893bce10dfR21) [[3]](diffhunk://#diff-bd8d23c132de1417c3f41cd2756dd7c79452266cd63fba97ca17c5893bce10dfR52)
* Updated attack animation to display damage as a negative value (e.g., "-9") as requested.

**Scene and State Management:**

* `GameScene` now tracks the player's entity key dynamically and prevents multiple concurrent animations, improving stability and correctness in state transitions. [[1]](diffhunk://#diff-bd8d23c132de1417c3f41cd2756dd7c79452266cd63fba97ca17c5893bce10dfR21) [[2]](diffhunk://#diff-bd8d23c132de1417c3f41cd2756dd7c79452266cd63fba97ca17c5893bce10dfR69-R72) [[3]](diffhunk://#diff-bd8d23c132de1417c3f41cd2756dd7c79452266cd63fba97ca17c5893bce10dfL112-R123)

**Documentation:**

* Updated the project report to document the new bug fixes, combat round limit feature, and refinements based on user feedback.