### PR TITLE
refactor: remove Player alias

### DIFF
--- a/apps/monstereditor/src/client/app.ts
+++ b/apps/monstereditor/src/client/app.ts
@@ -1,7 +1,7 @@
 import { Application, Assets } from 'pixi.js';
 import { MapRender } from '@proj-tower/maprender';
 import { CharacterEntity } from '@proj-tower/maprender';
-import { GameState, Player, Monster, TileAsset, ICharacter } from '@proj-tower/logic-core';
+import { GameState, IPlayer, IMonster, ITileAsset, ICharacter } from '@proj-tower/logic-core';
 
 // --- Type Definitions ---
 interface LevelData {
@@ -39,10 +39,10 @@ const zoomDisplay = document.getElementById('zoom-display') as HTMLSpanElement;
 
 
 // --- State ---
-let allMonsters: Monster[] = [];
+let allMonsters: IMonster[] = [];
 let levelData: LevelData[] = [];
-let selectedPlayer: Player | null = null;
-let selectedMonster: Monster | null = null;
+let selectedPlayer: IPlayer | null = null;
+let selectedMonster: IMonster | null = null;
 let mapRender: MapRender | null = null;
 let playerEntity: CharacterEntity | null = null;
 let monsterEntity: CharacterEntity | null = null;
@@ -173,7 +173,7 @@ function calculateDamage(attacker: ICharacter, defender: ICharacter): number {
     return damage <= 0 ? 1 : damage;
 }
 
-function simulateBattle(player: Player, monster: Monster): BattleResult {
+function simulateBattle(player: IPlayer, monster: IMonster): BattleResult {
     let playerHp = player.hp;
     let monsterHp = monster.maxhp;
     let turns = 0;
@@ -255,7 +255,7 @@ async function setupPixiApp() {
   ]);
 
   const emptyLayout = Array(16).fill(0).map(() => Array(16).fill(0));
-  const tileAssets: Record<string, TileAsset> = {
+  const tileAssets: Record<string, ITileAsset> = {
       '0': { assetId: 'map_floor', isEntity: false }
   };
   // Construct a MapLayout for GameState.map

--- a/packages/logic-core/src/types.ts
+++ b/packages/logic-core/src/types.ts
@@ -266,11 +266,6 @@ export interface MapLayout {
     stairs?: Record<string, IStair>;
 }
 
-// Backwards-compatible aliases: some apps import the non-I prefixed names.
-export type Player = IPlayer;
-export type Monster = IMonster;
-export type TileAsset = ITileAsset;
-
 export interface PlayerData {
     id: string;
     name: string;


### PR DESCRIPTION
This pull request updates the `monstereditor` client application to use the `I*`-prefixed interface types (`IPlayer`, `IMonster`, `ITileAsset`) from `logic-core` instead of the older non-prefixed type aliases (`Player`, `Monster`, `TileAsset`). This change improves type clarity and consistency across the codebase, especially as the non-prefixed type aliases have been removed from `logic-core`.

Type usage updates:

* Replaced all usages of `Player`, `Monster`, and `TileAsset` in `apps/monstereditor/src/client/app.ts` with their corresponding `IPlayer`, `IMonster`, and `ITileAsset` interface types to match the updated exports from `logic-core`. [[1]](diffhunk://#diff-a43f7aa790ed301a5fbeaf444a51a721c8b5d7b2586a45888955e35857f6a426L4-R4) [[2]](diffhunk://#diff-a43f7aa790ed301a5fbeaf444a51a721c8b5d7b2586a45888955e35857f6a426L42-R45) [[3]](diffhunk://#diff-a43f7aa790ed301a5fbeaf444a51a721c8b5d7b2586a45888955e35857f6a426L176-R176) [[4]](diffhunk://#diff-a43f7aa790ed301a5fbeaf444a51a721c8b5d7b2586a45888955e35857f6a426L258-R258)
* Removed the backwards-compatible type aliases (`Player`, `Monster`, `TileAsset`) from `packages/logic-core/src/types.ts`, so only the `I*`-prefixed interfaces are exported.